### PR TITLE
Fix for extra <cols/> element

### DIFF
--- a/simple-xlsx/xl/worksheets/worksheet.rkt
+++ b/simple-xlsx/xl/worksheets/worksheet.rkt
@@ -303,6 +303,7 @@
                   (loop-merge-cell-ranges (add1 loop_count)))))))
 
 (define (to-col-width-style)
+(when (not (null? (squeeze-range-hash (SHEET-STYLE-col->width_map (*CURRENT_SHEET_STYLE*)))))
   (append
    (list "cols")
    (let loop ([col_range_width_list (squeeze-range-hash (SHEET-STYLE-col->width_map (*CURRENT_SHEET_STYLE*)))]
@@ -317,7 +318,7 @@
             (cons "max" (number->string (second (car col_range_width_list))))
             (cons "width" (number->string (third (car col_range_width_list)))))
            result_list))
-         (reverse result_list)))))
+         (reverse result_list))))))
 
 (define (from-col-width-style xml_hash)
   (let ([col_range_width_list '()]


### PR DESCRIPTION
The writer was inserting an orphaned <cols/> element in the worksheet xml whenever the column styles had not been specifically set.  Line 307 in the original code is the culprit - even if no styles are set, a single <cols/> element will be returned, breaking the xml.  Then, when you attempt to open the file in Excel, it says that errors were detected in the file. For an example, the following code (taken from the docs) causes this error. 
(write-xlsx
  "basic.xlsx"
  (lambda ()
    (add-data-sheet "Sheet1" '(("month1" "month2" "month3" "month4" "real")))
    (add-data-sheet "Sheet2" '((201601 100 110 1110 6.9)))))

My fix is simply to check before that there are column styles, and if not, (to-col-width-style) doesn't return anything.