### PR TITLE
Do not include /_rels/ "sheets" in the list of actual sheets.

### DIFF
--- a/simple-xlsx/content-type.rkt
+++ b/simple-xlsx/content-type.rkt
@@ -97,7 +97,8 @@
         (when (<= override_index override_count)
           (let ([part_name (hash-ref xml_hash (format "Types1.Override~a.PartName1" override_index) "")])
             (cond
-             [(regexp-match #rx"worksheets" part_name)
+              [(and (regexp-match #rx"worksheets" part_name)
+                    (not (regexp-match #rx"_rels" part_name)))
               (add-data-sheet (format "Sheet~a" data_sheet_count) '(("none")))
               (loop (add1 override_index) (add1 data_sheet_count) chart_sheet_count)]
              [(regexp-match #rx"chartsheets" part_name)


### PR DESCRIPTION
Some OOXML spreadsheets contain paths which are incorrectly interpreted as another sheet within the workbook. The offending file has the following structure:

```
$ find .
.
./_rels
./_rels/.rels
./xl
./xl/_rels
./xl/_rels/workbook.xml.rels
./xl/theme
./xl/theme/theme1.xml
./xl/worksheets
./xl/worksheets/sheet1.xml
./xl/worksheets/_rels
./xl/worksheets/_rels/sheet1.xml.rels
./xl/sharedStrings.xml
./xl/styles.xml
./xl/workbook.xml
./docMetadata
./docMetadata/LabelInfo.xml
./docProps
./docProps/core.xml
./docProps/app.xml
./docProps/custom.xml
./[Content_Types].xml
```
This patch explicitly filters-out any "worksheets" which have "_rels" in their path name.